### PR TITLE
refactor FeiM monad

### DIFF
--- a/src/MXNet/NN/LrScheduler.hs
+++ b/src/MXNet/NN/LrScheduler.hs
@@ -11,6 +11,7 @@ class LrScheduler sch where
     getLR  :: sch -> Int -> Float
 
 instance LrScheduler Float where
+    baseLR = id
     getLR = const
 
 data Const = Const Float


### PR DESCRIPTION
This PR changes the `runFeiM` interface. It carries no longer an extra type variable.
```
class Feiable (m :: * -> *) where
    data FeiMType m a :: *
    runFeiM :: FeiMType m a -> IO a
```

`FeiMType` defines a `Monad` indexed by `m`. It can carry additional information to `runFeiM`, as `NeptFeiM` does.

There are two pre-defined `Feiable` type.
- `SimpleFeiM`, which is just a newtype wrapper of `ReaderT (FeiApp t n ()) (ResourceT IO) `. This is the simplest use case.
- `NeptFeiM`, which is equivalent to `SimpleFeiM` plus capability of logging to [Neptune](https://ui.neptune.ai).
