### PR TITLE
update to fei-base-2.0.0

### DIFF
--- a/fei-nn.cabal
+++ b/fei-nn.cabal
@@ -105,7 +105,7 @@ Library
                           , rio
                           , uuid
                           , type-sets
-                          , fei-base < 2.0.0
+                          , fei-base >= 2.0.0
     if flag(mxnet_geq_10600) {
         cpp-options:        -DMXNET_VERSION=10600
     }

--- a/src/MXNet/NN.hs
+++ b/src/MXNet/NN.hs
@@ -92,6 +92,7 @@ runFeiMX x body = do
     -- call mxListAllOpNames can ensure the MXNet itself is properly initialized
     -- i.e. MXNet operators are registered in the NNVM
     void mxListAllOpNames
+    void $ mxSetIsNumpyShape NpyShapeGL
     logopt  <- logOptionsHandle stdout False
     pcontx  <- mkDefaultProcessContext
     session <- newEmptyMVar
@@ -139,8 +140,8 @@ neptLog key value = do
 
 #endif
 
-initSession :: forall n t m x. (FloatDType t, Feiable m, MonadIO m, MonadReader (FeiApp t n x) m)
-            => SymbolHandle -> Config t -> m ()
+initSession :: forall n t m x. (HasCallStack, FloatDType t, Feiable m, MonadIO m, MonadReader (FeiApp t n x) m)
+            => Symbol t -> Config t -> m ()
 initSession sym cfg = do
     sess_ref <- view $ fa_session
     liftIO $ do

--- a/src/MXNet/NN/DataIter/Vec.hs
+++ b/src/MXNet/NN/DataIter/Vec.hs
@@ -1,14 +1,14 @@
+{-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE FlexibleInstances #-}
 module MXNet.NN.DataIter.Vec where
 
-import RIO
-import qualified RIO.NonEmpty as RNE
-import qualified RIO.Vector.Boxed as V
+import           RIO
+import           RIO.List                 (headMaybe)
+import qualified RIO.Vector.Boxed         as V
 import qualified RIO.Vector.Boxed.Partial as V (head)
 
-import MXNet.NN.DataIter.Class
-import MXNet.Base (NDArray, DType, ndshape)
+import           MXNet.Base               (DType, NDArray, ndshape)
+import           MXNet.NN.DataIter.Class
 
 newtype DatasetVector (m :: * -> *) a = DatasetVector { _dsv_unwrap :: Vector a }
 
@@ -25,16 +25,14 @@ instance Dataset DatasetVector where
     liftD (DatasetVector x) = DatasetVector x
 
 instance DType a => DatasetProp DatasetVector (NDArray a) where
-    batchSizeD (DatasetVector dat) = liftIO $ do
-        batch_size <- RNE.head <$> ndshape (V.head dat)
-        return $ Just batch_size
+    batchSizeD (DatasetVector dat) = liftIO $ headMaybe <$> ndshape (V.head dat)
 
 instance DType a => DatasetProp DatasetVector (NDArray a, NDArray a) where
     batchSizeD (DatasetVector dat) = do
         let (arr1, arr2) = V.head dat
         liftIO $ do
-            batch_size1 <- RNE.head <$> ndshape arr1
-            batch_size2 <- RNE.head <$> ndshape arr2
-            return $ if batch_size1 /= batch_size2
-                        then Nothing
-                        else Just batch_size1
+            s1 <- ndshape arr1
+            s2 <- ndshape arr2
+            return $ case (headMaybe s1, headMaybe s2) of
+              (Just b1, Just b2) | b1 == b2 -> Just b1
+              _                             -> Nothing

--- a/src/MXNet/NN/Initializer.hs
+++ b/src/MXNet/NN/Initializer.hs
@@ -2,18 +2,20 @@
 module MXNet.NN.Initializer where
 
 import           RIO
-import qualified RIO.NonEmpty                as RNE
 import qualified RIO.Text                    as T
 import qualified RIO.Vector.Storable         as SV
+import           Type.Set                    (Insert)
 
 import           MXNet.Base
 import qualified MXNet.Base.Operators.Tensor as T
-import           MXNet.Base.Tensor           (prim)
 import           MXNet.NN.Types
 import           MXNet.NN.Utils
 
+upd :: forall a. IO [NDArray a] -> IO ()
+upd = void
+
 empty :: DType a => Initializer a
-empty _ shp cxt = makeEmptyNDArray shp cxt
+empty _ arr = return ()
 
 zeros :: DType a => Initializer a
 zeros = constant 0
@@ -21,28 +23,27 @@ zeros = constant 0
 ones :: DType a => Initializer a
 ones  = constant 1
 
-constant :: DType a => a -> Initializer a
-constant val _ shp cxt = makeNDArray shp cxt $ SV.replicate (product shp) val
+constant :: forall a. DType a => Float -> Initializer a
+constant val _ arr = upd @a $ T.__set_value (#src := val .& Nil) (Just [arr])
 
-uniform :: forall a. (DType a, HasEnum (DTypeName a) '["None", "float16" ,"float32", "float64"])
-    => Float -> Initializer a
-uniform sca _ shp cxt = prim T.__random_uniform
-                               (  #low    := (-sca)
-                               .& #high   := sca
-                               .& #shape  := RNE.toList shp
-                               .& #ctx    := formatContext cxt
-                               .& #dtype  := EnumType (typename (undefined :: a))
-                               .& Nil)
+vector :: DType a => SV.Vector a -> Initializer a
+vector val _ arr = copyFromVector arr val
 
-normal :: forall a. (DType a, HasEnum (DTypeName a) '["None", "float16" ,"float32", "float64"])
+type BasicFloatDTypesWithNone = Insert "None" BasicFloatDTypes
+
+uniform :: forall a. (DType a, InEnum (DTypeName a) BasicFloatDTypesWithNone)
     => Float -> Initializer a
-normal sigma _ shp cxt = prim T.__random_normal
-                               (  #loc    := (0 :: Float)
-                               .& #scale  := sigma
-                               .& #shape  := RNE.toList shp
-                               .& #ctx    := formatContext cxt
-                               .& #dtype  := EnumType (typename (undefined :: a))
-                               .& Nil)
+uniform sca _ arr = upd @a $ T.__random_uniform
+                            (#low    := (-sca)
+                          .& #high   := sca
+                          .& Nil) (Just [arr])
+
+normal :: forall a. (DType a, InEnum (DTypeName a) BasicFloatDTypesWithNone)
+    => Float -> Initializer a
+normal sigma _ arr = upd @a $ T.__random_normal
+                             (#loc    := (0 :: Float)
+                           .& #scale  := sigma
+                           .& Nil) (Just [arr])
 
 data XavierFactor = XavierAvg
     | XavierIn
@@ -50,18 +51,20 @@ data XavierFactor = XavierAvg
 data XavierRandom = XavierUniform
     | XavierGaussian
 
-xavier :: (DType a, HasEnum (DTypeName a) '["None", "float16" ,"float32", "float64"])
+xavier :: (DType a, InEnum (DTypeName a) BasicFloatDTypesWithNone)
     => Float -> XavierRandom -> XavierFactor -> Initializer a
-xavier magnitude distr factor name shp cxt
-    | RNE.length shp < 2 = throwM $ InvalidArgument $
-        T.concat ["invalid shape ", formatShape shp, " for xavier initializer"]
-    | otherwise =
-        let ofan :| dims = shp
+xavier magnitude distr factor name arr = do
+    shp <- ndshape arr
+    if length shp < 2
+    then throwM $ InvalidArgument $
+            T.concat ["invalid shape ", formatShape shp, " for xavier initializer"]
+    else do
+        let ofan : dims = shp
             ifan = product dims
             scale = case factor of
                       XavierIn  -> sqrt (magnitude / fromIntegral ifan)
                       XavierOut -> sqrt (magnitude / fromIntegral ofan)
                       XavierAvg -> sqrt (magnitude * 2.0 / fromIntegral (ifan + ofan))
-        in case distr of
-             XavierUniform  -> uniform scale name shp cxt
-             XavierGaussian-> normal  scale name shp cxt
+        case distr of
+          XavierUniform  -> uniform scale name arr
+          XavierGaussian -> normal  scale name arr

--- a/src/MXNet/NN/Optimizer.hs
+++ b/src/MXNet/NN/Optimizer.hs
@@ -28,7 +28,7 @@ class Optimizer (opt :: * -> *) where
     -- | make the optimizer
     makeOptimizer :: (DType dtype, LrScheduler sch, OptimizerCst opt dtype args, MonadIO m)
                   => OptimizerTag opt -> sch
-                  -> ArgsHMap (OptimizerSym opt) (NDArray dtype) args
+                  -> ArgsHMap (OptimizerSym opt) '(NDArray, dtype) args
                   -> m (opt dtype)
     -- | run the optimizer with the input & expected tensor
     optimize :: (DType dtype, MonadState (TaggedModuleState dtype t) m, MonadIO m)
@@ -44,13 +44,13 @@ type family OptimizerCst (opt :: * -> *) dt (args :: [*]) :: Constraint
 -- | SGD optimizer
 data SGD_Opt dtype where
     SGD_Opt :: (LrScheduler sch, OptimizerCst SGD_Opt dtype args)
-            => sch -> ArgsHMap (OptimizerSym SGD_Opt) (NDArray dtype) args
+            => sch -> ArgsHMap (OptimizerSym SGD_Opt) '(NDArray, dtype) args
             -> SGD_Opt dtype
 
 type instance OptimizerSym SGD_Opt = "_sgd_update"
 -- 1.0.0 type instance OptimizerCst SGD_Opt dt args = HasArgs (OptimizerSym SGD_Opt) args '["wd", "rescale_grad", "clip_gradient"]
 type instance OptimizerCst SGD_Opt dt args =
-    HasArgs (OptimizerSym SGD_Opt) (NDArray dt) args '["wd", "rescale_grad", "clip_gradient", "lazy_update"]
+    HasArgs (OptimizerSym SGD_Opt) '(NDArray, dt) args '["wd", "rescale_grad", "clip_gradient", "lazy_update"]
 
 instance Optimizer SGD_Opt where
     data OptimizerTag SGD_Opt = SGD
@@ -67,14 +67,14 @@ instance Optimizer SGD_Opt where
 -- | SGD with momentum optimizer
 data SGD_Mom_Opt dtype where
     SGD_Mom_Opt :: (LrScheduler sch, OptimizerCst SGD_Mom_Opt dtype args)
-                => sch -> ArgsHMap (OptimizerSym SGD_Mom_Opt) (NDArray dtype) args
+                => sch -> ArgsHMap (OptimizerSym SGD_Mom_Opt) '(NDArray, dtype) args
                 -> (IORef (M.HashMap Text (NDArray dtype)))
                 -> SGD_Mom_Opt dtype
 
 type instance OptimizerSym SGD_Mom_Opt = "_sgd_mom_update"
 -- 1.0.0 type instance OptimizerCst SGD_Mom_Opt dt args = HasArgs (OptimizerSym SGD_Mom_Opt) args '["momentum", "wd", "rescale_grad", "clip_gradient"]
 type instance OptimizerCst SGD_Mom_Opt dt args =
-    HasArgs (OptimizerSym SGD_Mom_Opt) (NDArray dt) args '["momentum", "wd", "rescale_grad", "clip_gradient", "lazy_update"]
+    HasArgs (OptimizerSym SGD_Mom_Opt) '(NDArray, dt) args '["momentum", "wd", "rescale_grad", "clip_gradient", "lazy_update"]
 
 instance Optimizer SGD_Mom_Opt where
     data OptimizerTag SGD_Mom_Opt = SGD'Mom
@@ -110,14 +110,14 @@ instance Optimizer SGD_Mom_Opt where
 -- | ADAM optmizer
 data ADAM_Opt dtype where
     ADAM_Opt :: (LrScheduler sch, OptimizerCst ADAM_Opt dtype args)
-            => sch -> ArgsHMap (OptimizerSym ADAM_Opt) (NDArray dtype) args
+            => sch -> ArgsHMap (OptimizerSym ADAM_Opt) '(NDArray, dtype) args
             -> IORef (M.HashMap Text (NDArray dtype, NDArray dtype))
             -> ADAM_Opt dtype
 
 type instance OptimizerSym ADAM_Opt = "_adam_update"
 -- 1.0.0 type instance OptimizerCst ADAM_Opt dt args = HasArgs (OptimizerSym ADAM_Opt) args '["beta1", "beta2", "epsilon", "wd", "rescale_grad", "clip_gradient"]
 type instance OptimizerCst ADAM_Opt dt args =
-    HasArgs (OptimizerSym ADAM_Opt) (NDArray dt) args '["beta1", "beta2", "epsilon", "wd", "rescale_grad", "clip_gradient", "lazy_update"]
+    HasArgs (OptimizerSym ADAM_Opt) '(NDArray, dt) args '["beta1", "beta2", "epsilon", "wd", "rescale_grad", "clip_gradient", "lazy_update"]
 
 instance Optimizer ADAM_Opt where
     data OptimizerTag ADAM_Opt = ADAM
@@ -150,13 +150,13 @@ instance Optimizer ADAM_Opt where
 
 data ADAMW_Opt dtype where
     ADAMW_Opt :: (LrScheduler sch, OptimizerCst ADAMW_Opt dtype args)
-              => sch -> ArgsHMap (OptimizerSym ADAMW_Opt) (NDArray dtype) args
+              => sch -> ArgsHMap (OptimizerSym ADAMW_Opt) '(NDArray, dtype) args
               -> IORef (M.HashMap Text (NDArray dtype, NDArray dtype))
               -> ADAMW_Opt dtype
 
 type instance OptimizerSym ADAMW_Opt = "__adamw_update"
 type instance OptimizerCst ADAMW_Opt dt args =
-    HasArgs (OptimizerSym ADAMW_Opt) (NDArray dt) args
+    HasArgs (OptimizerSym ADAMW_Opt) '(NDArray, dt) args
             '["beta1", "beta2", "epsilon", "wd", "eta", "clip_gradient", "rescale_grad"]
 
 instance Optimizer ADAMW_Opt where

--- a/src/MXNet/NN/Utils/GraphViz.hs
+++ b/src/MXNet/NN/Utils/GraphViz.hs
@@ -11,7 +11,6 @@ import qualified Data.GraphViz                     as GV
 import qualified Data.GraphViz.Attributes.Complete as GV
 import qualified Data.GraphViz.Types.Generalised   as GVM
 import qualified Data.GraphViz.Types.Monadic       as GVM
-import           Data.Typeable                     (Typeable)
 import           Formatting
 import           Numeric                           (readHex)
 import           RIO

--- a/src/MXNet/NN/Utils/Render.hs
+++ b/src/MXNet/NN/Utils/Render.hs
@@ -40,7 +40,7 @@ drawBox color stroke_width x0 y0 x1 y1 label = do
                in G.printTextAt font (G.PointSize size) (G.V2 (x0+2) (y0+size+2)) text_str
 
 
-data NotConvertible = NotConvertible (NonEmpty Int)
+data NotConvertible = NotConvertible [Int]
     deriving Show
 instance Exception NotConvertible
 


### PR DESCRIPTION
1. `ndarray` uses numpy's semantics
2. Deprecate to way layer-building with `SymbolHandle`. Now the `Symbol` is enforced.
3. `Symbol` has internal attributes (all should be in `String` form):
  - `__shape__`: [Int], the shape of the
  - `__init__`: ["zero", {}], ["int", {}], or Float, or [Float]
  - `__dtype__`: "float32", "float64", "uint8", "int32", "int64"
  - `__storage_type__`: only  "default" is allowed
  - `__grad_req__`: "write", "null", "add", "in place"