### PR TITLE
update symbol initializer

### DIFF
--- a/src/MXNet/NN.hs
+++ b/src/MXNet/NN.hs
@@ -140,7 +140,12 @@ neptLog key value = do
 
 #endif
 
-initSession :: forall n t m x. (HasCallStack, FloatDType t, Feiable m, MonadIO m, MonadReader (FeiApp t n x) m)
+initSession :: forall n t m x. (HasCallStack,
+                                FloatDType t,
+                                InEnum (DTypeName t) BasicFloatDTypes,
+                                Feiable m,
+                                MonadIO m,
+                                MonadReader (FeiApp t n x) m)
             => Symbol t -> Config t -> m ()
 initSession sym cfg = do
     sess_ref <- view $ fa_session

--- a/src/MXNet/NN/Initializer.hs
+++ b/src/MXNet/NN/Initializer.hs
@@ -1,10 +1,11 @@
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 module MXNet.NN.Initializer where
 
+import           GHC.Read
 import           RIO
 import qualified RIO.Text                    as T
 import qualified RIO.Vector.Storable         as SV
-import           Type.Set                    (Insert)
 
 import           MXNet.Base
 import qualified MXNet.Base.Operators.Tensor as T
@@ -14,57 +15,60 @@ import           MXNet.NN.Utils
 upd :: forall a. IO [NDArray a] -> IO ()
 upd = void
 
-empty :: DType a => Initializer a
-empty _ arr = return ()
+data SimpleInit a = InitEmpty | InitZeros | InitOnes | InitWithVal Float | InitWithVec (SV.Vector a)
+    deriving (Show, Read)
 
-zeros :: DType a => Initializer a
-zeros = constant 0
+instance DType a => Initializer SimpleInit a where
+    initNDArray InitEmpty _ _              = return ()
+    initNDArray InitZeros name arr         = constant 0 name arr
+    initNDArray InitOnes  name arr         = constant 1 name arr
+    initNDArray (InitWithVal val) name arr = constant val name arr
+    initNDArray (InitWithVec val) _ arr    = copyFromVector arr val
 
-ones :: DType a => Initializer a
-ones  = constant 1
-
-constant :: forall a. DType a => Float -> Initializer a
+constant :: forall a. DType a => Float -> Text -> NDArray a -> IO ()
 constant val _ arr = upd @a $ T.__set_value (#src := val .& Nil) (Just [arr])
 
-vector :: DType a => SV.Vector a -> Initializer a
-vector val _ arr = copyFromVector arr val
-
-type BasicFloatDTypesWithNone = Insert "None" BasicFloatDTypes
-
-uniform :: forall a. (DType a, InEnum (DTypeName a) BasicFloatDTypesWithNone)
-    => Float -> Initializer a
-uniform sca _ arr = upd @a $ T.__random_uniform
-                            (#low    := (-sca)
-                          .& #high   := sca
-                          .& Nil) (Just [arr])
-
-normal :: forall a. (DType a, InEnum (DTypeName a) BasicFloatDTypesWithNone)
-    => Float -> Initializer a
-normal sigma _ arr = upd @a $ T.__random_normal
-                             (#loc    := (0 :: Float)
-                           .& #scale  := sigma
-                           .& Nil) (Just [arr])
+data RandomInit a = InitUniform Float
+                  | InitNormal  Float
+                  | InitXavier  Float XavierRandom XavierFactor
+    deriving (Show, Read)
 
 data XavierFactor = XavierAvg
     | XavierIn
     | XavierOut
+    deriving (Show, Read)
 data XavierRandom = XavierUniform
     | XavierGaussian
+    deriving (Show, Read)
 
-xavier :: (DType a, InEnum (DTypeName a) BasicFloatDTypesWithNone)
-    => Float -> XavierRandom -> XavierFactor -> Initializer a
-xavier magnitude distr factor name arr = do
-    shp <- ndshape arr
-    if length shp < 2
-    then throwM $ InvalidArgument $
-            T.concat ["invalid shape ", formatShape shp, " for xavier initializer"]
-    else do
-        let ofan : dims = shp
-            ifan = product dims
-            scale = case factor of
-                      XavierIn  -> sqrt (magnitude / fromIntegral ifan)
-                      XavierOut -> sqrt (magnitude / fromIntegral ofan)
-                      XavierAvg -> sqrt (magnitude * 2.0 / fromIntegral (ifan + ofan))
-        case distr of
-          XavierUniform  -> uniform scale name arr
-          XavierGaussian -> normal  scale name arr
+instance (DType a, InEnum (DTypeName a) BasicFloatDTypes)
+  => Initializer RandomInit a where
+    initNDArray (InitUniform sca) _ arr =
+        upd @a $ T.__random_uniform (#low    := (-sca)
+                                  .& #high   := sca
+                                  .& Nil) (Just [arr])
+    initNDArray (InitNormal sigma) _ arr =
+        upd @a $ T.__random_normal (#loc    := (0 :: Float)
+                                 .& #scale  := sigma
+                                 .& Nil) (Just [arr])
+    initNDArray (InitXavier magnitude distr factor) name arr = do
+        shp <- ndshape arr
+        if length shp < 2
+        then throwM $ InvalidArgument $
+                T.concat ["invalid shape ", formatShape shp, " for xavier initializer"]
+        else do
+            let ofan : dims = shp
+                ifan = product dims
+                scale = case factor of
+                          XavierIn  -> sqrt (magnitude / fromIntegral ifan)
+                          XavierOut -> sqrt (magnitude / fromIntegral ofan)
+                          XavierAvg -> sqrt (magnitude * 2.0 / fromIntegral (ifan + ofan))
+            case distr of
+              XavierUniform  -> initNDArray (InitUniform scale) name arr
+              XavierGaussian -> initNDArray (InitNormal  scale) name arr
+
+
+newtype CustomInit a = CustomInit (Text -> NDArray a -> IO ())
+
+instance DType a => Initializer CustomInit a where
+    initNDArray (CustomInit func) name arr = func name arr

--- a/src/MXNet/NN/Utils.hs
+++ b/src/MXNet/NN/Utils.hs
@@ -90,7 +90,7 @@ loadState weights_filename ignores = do
             (_, Nothing, Just name', Just (ParameterG _ target)) -> do
                 checkShape name' (NDArray hdl) target
                 liftIO $ void $ copy (NDArray hdl) target
-            (_, Nothing, Just name', Just _) -> do
+            (_, Nothing, Just _, Just _) -> do
                 -- we silently ignore any missing grad,
                 -- for it is too common if we load the model for inference
                 return ()
@@ -105,6 +105,8 @@ loadState weights_filename ignores = do
             (_, Just (ParameterA target), _, _)   -> do
                 checkShape name (NDArray hdl) target
                 liftIO $ void $ copy (NDArray hdl) target
+            (_, _, Nothing, Just _) -> do
+                error "This won't happen"
     where
         checkShape :: (MonadReader env m, HasLogFunc env, MonadIO m, DType a)
                    => Text -> NDArray a -> NDArray a -> m ()


### PR DESCRIPTION
This PR introduces breaking changes on the APIs for initializers.

The module config carries a `SomeInitializer a` per-symbol or by default.
```
data Config a = Config
    { ...
    , _cfg_initializers        :: HashMap Text (SomeInitializer a)
    , _cfg_default_initializer :: SomeInitializer a
    ...
    }

data SomeInitializer a = forall n . Initializer n a => SomeInitializer (n a)

class DType a => Initializer n a where
    initNDArray :: n a -> Text -> NDArray a -> IO ()

```

Some instances of `Initializer` class
- `data SimpleInit a = ...`
- `data RandomInit a = ...`
- `newtype CustomInit a = CustomInit (Text -> NDArray a -> IO ())`

----

You can set an initializer for a `Symbol a`. Although the type requires only `Show` class, you can only designate a `SimpleInit` or `RandomInit`, because the type is eliminated at runtime and module initialization cannot tell which concrete type it is (limited possibility of `read`).
```
initWith :: (Initializer n a, Show (n a))
         => n a -> Symbol a -> Layer (Symbol a)
```