### PR TITLE
inference with shared parameters

### DIFF
--- a/fei-nn.cabal
+++ b/fei-nn.cabal
@@ -119,3 +119,18 @@ Library
         cpp-options:        -DNEPTUNE
         build-depends:      neptune-backend < 1
     }
+
+test-suite tests
+  type:                     exitcode-stdio-1.0
+  hs-source-dirs:           test
+  main-is:                  TestMain.hs
+  other-modules:            TestModule
+  build-depends:            rio
+                          , base
+                          , lens
+                          , tasty
+                          , tasty-hunit
+                          , tasty-discover
+                          , fei-base >= 2.0.0
+                          , fei-nn >= 2.0.0
+  default-language:         Haskell2010

--- a/src/MXNet/NN.hs
+++ b/src/MXNet/NN.hs
@@ -13,6 +13,7 @@ module MXNet.NN (
     module MXNet.NN.Layer,
     module MXNet.NN.Types,
     module MXNet.NN.Utils,
+    module MXNet.NN.Initializer,
 #if USE_REPA
     module MXNet.NN.Utils.Repa,
 #endif
@@ -24,11 +25,14 @@ module MXNet.NN (
     FeiApp,
     Feiable(..),
     FeiMType(..),
+    SimpleFeiM(..),
+    runFeiMX,
     fa_log_func,
     fa_process_context,
     fa_session,
     fa_extra,
 #ifdef NEPTUNE
+    NeptFeiM(..),
     NeptExtra,
     neptLog,
 #endif
@@ -44,6 +48,7 @@ import           MXNet.Base
 import           MXNet.NN.Callback
 import           MXNet.NN.DataIter.Class
 import           MXNet.NN.EvalMetric
+import           MXNet.NN.Initializer
 import           MXNet.NN.Layer
 import           MXNet.NN.LrScheduler
 import           MXNet.NN.Module
@@ -77,8 +82,8 @@ instance HasLogFunc (FeiApp t n x) where
 instance HasSessionRef (FeiApp t n x) (TaggedModuleState t n) where
     sessionRefL = fa_session
 
-newtype SimpleFeiM t n a = SimpleFeiM (ReaderT (FeiApp t n ()) (ResourceT IO) a)
-    deriving (Functor, Applicative, Monad, MonadIO, MonadFail)
+newtype SimpleFeiM t n a = SimpleFeiM {unSimpleFeiM :: ReaderT (FeiApp t n ()) (ResourceT IO) a}
+    deriving (Functor, Applicative, Monad, MonadIO, MonadFail, MonadThrow)
 
 deriving instance MonadReader (FeiApp t n ()) (SimpleFeiM t n)
 instance MonadUnliftIO (SimpleFeiM t n) where
@@ -87,8 +92,8 @@ instance MonadUnliftIO (SimpleFeiM t n) where
                                 \case SimpleFeiM m -> run m
 
 
-runFeiMX :: x -> ReaderT (FeiApp t n x) (ResourceT IO) a -> IO a
-runFeiMX x body = do
+runFeiMX :: x -> Bool -> ReaderT (FeiApp t n x) (ResourceT IO) a -> IO a
+runFeiMX x notify_shutdown body = do
     -- call mxListAllOpNames can ensure the MXNet itself is properly initialized
     -- i.e. MXNet operators are registered in the NNVM
     void mxListAllOpNames
@@ -97,9 +102,9 @@ runFeiMX x body = do
     pcontx  <- mkDefaultProcessContext
     session <- newEmptyMVar
     runResourceT $ do
-        _ <- register mxNotifyShutdown
+        when notify_shutdown $ void $ register mxNotifyShutdown
         withLogFunc logopt $ \logfunc ->
-            flip runReaderT (FeiApp logfunc pcontx session x) body
+            runReaderT body (FeiApp logfunc pcontx session x)
 
 class Feiable (m :: * -> *) where
     data FeiMType m a :: *
@@ -111,14 +116,14 @@ instance Exception SessionAlreadyExist
 
 instance Feiable (SimpleFeiM t n) where
     data FeiMType (SimpleFeiM t n) a = Simple (SimpleFeiM t n a)
-    runFeiM (Simple (SimpleFeiM body)) = runFeiMX () body
+    runFeiM (Simple (SimpleFeiM body)) = runFeiMX () True body
 
 #ifdef NEPTUNE
 
 type NeptExtra = (NeptuneSession, Experiment, Text -> Double -> IO ())
 
-newtype NeptFeiM t n a = NeptFeiM (ReaderT (FeiApp t n NeptExtra) (ResourceT IO) a)
-    deriving (Functor, Applicative, Monad, MonadIO, MonadFail)
+newtype NeptFeiM t n a = NeptFeiM {unNeptFeiM :: ReaderT (FeiApp t n NeptExtra) (ResourceT IO) a}
+    deriving (Functor, Applicative, Monad, MonadIO, MonadFail, MonadThrow)
 
 deriving instance MonadReader (FeiApp t n NeptExtra) (NeptFeiM t n)
 instance MonadUnliftIO (NeptFeiM t n) where
@@ -131,7 +136,7 @@ instance Feiable (NeptFeiM t n) where
     runFeiM (WithNept project (NeptFeiM body)) = do
         withNept project $ \ nsess nexpt ->
             let logger k v = nlog nexpt k (fromRational (toRational v) :: Double)
-             in runFeiMX (nsess, nexpt, logger) body
+             in runFeiMX (nsess, nexpt, logger) True body
 
 neptLog :: Text -> Double -> NeptFeiM t n ()
 neptLog key value = do

--- a/src/MXNet/NN/EvalMetric.hs
+++ b/src/MXNet/NN/EvalMetric.hs
@@ -9,18 +9,18 @@
 module MXNet.NN.EvalMetric where
 
 import           Control.Lens
-import           Data.Constraint
-import           Formatting                  (fixed, int, sformat, stext, (%))
-import           RIO                         hiding (view)
-import qualified RIO.HashMap                 as M
-import           RIO.List                    (headMaybe)
-import           RIO.State                   (execState)
-import qualified RIO.Text                    as T
-import qualified RIO.Vector.Storable         as SV
-import qualified RIO.Vector.Storable.Partial as SV (head)
+import           Formatting                   (fixed, int, sformat, stext, (%))
+import           RIO                          hiding (view)
+import qualified RIO.HashMap                  as M
+import           RIO.List                     (headMaybe)
+import           RIO.State                    (execState)
+import qualified RIO.Text                     as T
+import qualified RIO.Vector.Storable          as SV
+import qualified RIO.Vector.Storable.Partial  as SV (head)
 
 import           MXNet.Base
-import           MXNet.Base.Operators.Tensor (_norm)
+import           MXNet.Base.Operators.Tensor  (_norm)
+import           MXNet.Base.Tensor.Functional
 
 -- | Keep a double value and its running mean
 data RunningValue = RunningValue

--- a/src/MXNet/NN/Initializer.hs
+++ b/src/MXNet/NN/Initializer.hs
@@ -20,13 +20,13 @@ data SimpleInit a = InitEmpty | InitZeros | InitOnes | InitWithVal Float | InitW
 
 instance DType a => Initializer SimpleInit a where
     initNDArray InitEmpty _ _              = return ()
-    initNDArray InitZeros name arr         = constant 0 name arr
-    initNDArray InitOnes  name arr         = constant 1 name arr
-    initNDArray (InitWithVal val) name arr = constant val name arr
+    initNDArray InitZeros name arr         = _constant 0 name arr
+    initNDArray InitOnes  name arr         = _constant 1 name arr
+    initNDArray (InitWithVal val) name arr = _constant val name arr
     initNDArray (InitWithVec val) _ arr    = copyFromVector arr val
 
-constant :: forall a. DType a => Float -> Text -> NDArray a -> IO ()
-constant val _ arr = upd @a $ T.__set_value (#src := val .& Nil) (Just [arr])
+_constant :: forall a. DType a => Float -> Text -> NDArray a -> IO ()
+_constant val _ arr = upd @a $ T.__set_value (#src := val .& Nil) (Just [arr])
 
 data RandomInit a = InitUniform Float
                   | InitNormal  Float

--- a/src/MXNet/NN/LrScheduler.hs
+++ b/src/MXNet/NN/LrScheduler.hs
@@ -1,12 +1,11 @@
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeOperators    #-}
 module MXNet.NN.LrScheduler where
 
 import           MXNet.Base.Spec.Operator
 import           RIO                      hiding (Const)
 
-class LrScheduler sch where
+class Show sch => LrScheduler sch where
     baseLR :: sch -> Float
     getLR  :: sch -> Int -> Float
 
@@ -14,7 +13,8 @@ instance LrScheduler Float where
     baseLR = id
     getLR = const
 
-data Const = Const Float
+newtype Const = Const Float
+    deriving Show
 instance LrScheduler Const where
     baseLR (Const lr) = lr
     getLR  (Const lr) = const lr
@@ -23,6 +23,7 @@ lrOfConst :: Float -> Const
 lrOfConst = Const
 
 data FactorScheduler = Factor Float Float Int Float
+    deriving Show
 instance LrScheduler FactorScheduler where
     baseLR (Factor base _ _ _) = base
     getLR  (Factor base factor step stop) nup =
@@ -43,6 +44,7 @@ lrOfFactor args = Factor base factor step stop
     stop   = fromMaybe 1e-8 (args !? #stop)
 
 data MultifactorScheduler = Multifactor Float Float [Int]
+    deriving Show
 instance LrScheduler MultifactorScheduler where
     baseLR (Multifactor base _ _) = base
     getLR  (Multifactor base factor steps) nup = base * factor ^ (index nup steps)
@@ -63,6 +65,7 @@ lrOfMultifactor args = Multifactor base factor steps
     base = fromMaybe 0.01 (args !? #base)
 
 data PolyScheduler = Poly Float Float Int
+    deriving Show
 instance LrScheduler PolyScheduler where
     baseLR (Poly base _ _) = base
     getLR  (Poly base power maxnup) nup =
@@ -82,6 +85,7 @@ lrOfPoly args = Poly base power maxnup
     power  = fromMaybe 2    (args !? #power)
 
 data WarmupScheduler a = WarmupScheduler Int a
+    deriving Show
 instance LrScheduler a => LrScheduler (WarmupScheduler a) where
     baseLR (WarmupScheduler _ sch) = baseLR sch
     getLR  (WarmupScheduler warmup_steps sch) nup =

--- a/src/MXNet/NN/Optimizer.hs
+++ b/src/MXNet/NN/Optimizer.hs
@@ -68,7 +68,7 @@ instance Optimizer SGD_Opt where
 data SGD_Mom_Opt dtype where
     SGD_Mom_Opt :: (LrScheduler sch, OptimizerCst SGD_Mom_Opt dtype args)
                 => sch -> ArgsHMap (OptimizerSym SGD_Mom_Opt) '(NDArray, dtype) args
-                -> (IORef (M.HashMap Text (NDArray dtype)))
+                -> IORef (M.HashMap Text (NDArray dtype))
                 -> SGD_Mom_Opt dtype
 
 type instance OptimizerSym SGD_Mom_Opt = "_sgd_mom_update"

--- a/src/MXNet/NN/Types.hs
+++ b/src/MXNet/NN/Types.hs
@@ -86,6 +86,14 @@ data Statistics = Statistics
     , _stat_last_lr :: !Float
     }
 
+hasGradient :: Parameter a -> Bool
+hasGradient (ParameterG _ _) = True
+hasGradient _                = False
+
+isAuxiliary :: Parameter a -> Bool
+isAuxiliary (ParameterA _) = True
+isAuxiliary _              = False
+
 makeLenses ''Statistics
 makeLenses ''ModuleState
 makeLenses ''Config

--- a/src/MXNet/NN/Utils.hs
+++ b/src/MXNet/NN/Utils.hs
@@ -2,23 +2,25 @@
 {-# LANGUAGE RecordWildCards       #-}
 module MXNet.NN.Utils where
 
-import           Control.Lens         (use)
+import           Control.Lens                 (use)
 import           Formatting
 import           RIO
-import           RIO.Directory        (getModificationTime, listDirectory)
-import           RIO.FilePath         (dropExtension, (</>))
-import qualified RIO.HashMap          as M
-import           RIO.List             (intersperse, lastMaybe, sortOn)
-import qualified RIO.Text             as T
+import           RIO.Directory                (getModificationTime,
+                                               listDirectory)
+import           RIO.FilePath                 (dropExtension, (</>))
+import qualified RIO.HashMap                  as M
+import           RIO.List                     (intersperse, lastMaybe, sortOn)
+import qualified RIO.Text                     as T
 
-import           MXNet.Base           (Context (..), DType, NDArray (..),
-                                       Symbol (..), ndshape)
-import           MXNet.Base.Raw       (mxNDArrayLoad, mxNDArraySave,
-                                       mxSymbolSaveToFile)
-import           MXNet.Base.Tensor    (copy)
-import           MXNet.NN.TaggedState (untag)
-import           MXNet.NN.Types       (Module, Parameter (..), mod_params,
-                                       mod_symbol)
+import           MXNet.Base                   (Context (..), DType,
+                                               NDArray (..), Symbol (..),
+                                               ndshape)
+import           MXNet.Base.Raw               (mxNDArrayLoad, mxNDArraySave,
+                                               mxSymbolSaveToFile)
+import           MXNet.Base.Tensor.Functional (copy)
+import           MXNet.NN.TaggedState         (untag)
+import           MXNet.NN.Types               (Module, Parameter (..),
+                                               mod_params, mod_symbol)
 
 -- | format a shape
 formatShape :: [Int] -> Text

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,6 +20,9 @@ extra-deps:
   commit: 792ec73bc3b0e8d4aa2683af6b2a3fc03b5f8d95
 - streaming-utils-0.1.4.7
 - graphviz-2999.20.0.4
+- type-sets-0.1.1.0
+- cmptype-0.2.0.0
+- magic-tyfams-0.1.1.0
 extra-include-dirs:
 - /home/jiasen/workspace/mxnet/build-1.8.0/include
 extra-lib-dirs:

--- a/test/TestMain.hs
+++ b/test/TestMain.hs
@@ -1,0 +1,2 @@
+
+{-# OPTIONS_GHC -F -pgmF tasty-discover #-}

--- a/test/TestModule.hs
+++ b/test/TestModule.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedLabels  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+module TestModule where
+
+import           Control.Lens                 (ix, use, (^?!), (^?))
+import           RIO                          hiding (Const (..))
+import qualified RIO.HashMap                  as M
+import qualified RIO.HashSet                  as S
+import qualified RIO.Vector.Storable          as VS
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+import           MXNet.Base
+import           MXNet.Base.Operators.Tensor  as T
+import           MXNet.Base.Tensor.Functional as F
+import           MXNet.NN
+import           MXNet.NN.Layer
+import           MXNet.NN.Module
+
+mkSymbol :: Layer (Symbol Float)
+mkSymbol = do
+    x <- variable "x"
+    unique "features" $ do
+        m <- named "m" $ parameter "m" ReqWrite (Just [4, 4])
+        o <- prim T.__npi_matmul (#a := x .& #b := m .& Nil)
+        l <- F.sum_ o Nothing False >>= F.reshape [1]
+        l <- makeLoss l 1.0
+        o <- blockGrad o
+        group [o, l]
+
+mkSymbolNoLoss :: Layer (Symbol Float)
+mkSymbolNoLoss = do
+    x <- variable "x"
+    unique "features" $ do
+        m <- named "m" $ parameter "m" ReqWrite (Just [4, 4])
+        prim T.__npi_matmul (#a := x .& #b := m .& Nil)
+
+mkConfig  = Config {
+    _cfg_data = M.fromList [("x", [1, 4])],
+    _cfg_label = [],
+    _cfg_initializers = M.empty,
+    _cfg_default_initializer = SomeInitializer InitOnes,
+    _cfg_fixed_params = S.fromList [],
+    _cfg_context = contextCPU }
+
+test_train_step :: TestTree
+test_train_step = testCase "Test fitAndEval" step
+    where
+    -- instead of 'runFei . Simple', we have to use the 'runFeiMX'
+    -- interface because we cannot send NotifyShutdown to mxnet.
+    step = runFeiMX () False . unSimpleFeiM $ do
+        x <- liftIO $ ndOnes [1, 4]
+        sym <- runLayerBuilder mkSymbol
+        initSession @"test" sym mkConfig
+        optm <- makeOptimizer SGD'Mom (Const 0.1) Nil
+        askSession $ do
+            let mapping = M.fromList [("x", x)]
+            fitAndEval optm mapping MNilData
+            params <- use $ untag . mod_params
+            case params ^? ix "features.m" of
+                Just (ParameterG p g) -> liftIO $ do
+                    p <- toVector p
+                    g <- toVector g
+                    assertBool "param == 0.9" $ VS.all (== 0.9) p
+                    assertBool "gradient == 1.0" $ VS.all (== 1.0) g
+                Just _  -> liftIO $ assertFailure "param 'm' has no gradient"
+                Nothing -> liftIO $ assertFailure "param 'm' exists"
+
+test_forward :: TestTree
+test_forward = testCase "Test forwardOnly" step
+    where
+    step = runFeiMX () False . unSimpleFeiM $ do
+        x <- liftIO $ ndOnes [1, 4]
+        sym <- runLayerBuilder mkSymbol
+        initSession @"test" sym mkConfig
+        askSession $ do
+            let mapping = M.fromList [("x", x)]
+            out <- forwardOnly mapping
+            liftIO $ do
+                assertBool "two outputs" $ length out == 2
+                out <- toVector $ out ^?! ix 0
+                assertBool "output == 4.0" $ VS.all (== 4.0) out
+
+
+test_shared_forward :: TestTree
+test_shared_forward = testCase "Test forwardOnly with shared parameters" step
+    where
+    step = runFeiMX () False . unSimpleFeiM $ do
+        sym <- runLayerBuilder mkSymbol
+        sym_shared <- runLayerBuilder mkSymbolNoLoss
+        initSession @"test" sym mkConfig
+        askSession $ do
+            let mapping = M.fromList [("x", [2, 4])]
+            withSharedParameters sym_shared mapping $ \forward -> do
+                x <- ndOnes [2, 4]
+                out <- forward (M.fromList [("x", x)])
+                assertBool "two outputs" $ length out == 1
+                out <- toVector $ out ^?! ix 0
+                assertBool "output == 4.0" $ VS.all (== 4.0) out
+
+                x <- fromVector [2, 4] (VS.replicate 8 0.5)
+                out <- forward (M.fromList [("x", x)])
+                assertBool "two outputs" $ length out == 1
+                out <- toVector $ out ^?! ix 0
+                assertBool "output == 2.0" $ VS.all (== 2.0) out


### PR DESCRIPTION
1. `runFeiMX` take a extra argument `notify_shutdown` to indicate whether calling `mxNotifyShutdown`. It needs to be False when running multiple passes. Calling MXNet APIs will block execution after notifying shutdown.
2. add an API `withSharedParameters`. It builds a shared executor (w.r.t the executor within the current Module) to run passes of inferences.
```
withSharedParameters :: (HasCallStack, FloatDType dty, MonadIO m, MonadThrow m)
                    => Symbol dty
                    -> HashMap Text [Int]
                    -> ((HashMap Text (NDArray dty) -> IO [NDArray dty]) -> IO a)
                    -> Module tag dty m a
```